### PR TITLE
Fix typo in the list directories API documentation

### DIFF
--- a/awswrangler/s3/_list.py
+++ b/awswrangler/s3/_list.py
@@ -192,15 +192,15 @@ def list_directories(path: str, boto3_session: Optional[boto3.Session] = None) -
     Using the default boto3 session
 
     >>> import awswrangler as wr
-    >>> wr.s3.list_objects('s3://bucket/prefix/')
-    ['s3://bucket/prefix/dir0', 's3://bucket/prefix/dir1', 's3://bucket/prefix/dir2']
+    >>> wr.s3.list_directories('s3://bucket/prefix/')
+    ['s3://bucket/prefix/dir0/', 's3://bucket/prefix/dir1/', 's3://bucket/prefix/dir2/']
 
     Using a custom boto3 session
 
     >>> import boto3
     >>> import awswrangler as wr
-    >>> wr.s3.list_objects('s3://bucket/prefix/', boto3_session=boto3.Session())
-    ['s3://bucket/prefix/dir0', 's3://bucket/prefix/dir1', 's3://bucket/prefix/dir2']
+    >>> wr.s3.list_directories('s3://bucket/prefix/', boto3_session=boto3.Session())
+    ['s3://bucket/prefix/dir0/', 's3://bucket/prefix/dir1/', 's3://bucket/prefix/dir2/']
 
     """
     return _list_objects(path=path, delimiter="/", boto3_session=boto3_session)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
The S3 list_directories API examples has list_objects in code syntax instead of list_directories method


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
